### PR TITLE
Fix typos and tidy up some pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -73,17 +73,14 @@ permalink: pretty
 
 languages:
   -
-    - en
-    - English
-  -
-    - id
-    - Bahasa
-  -
     - de
     - Deutsch
   -
     - el
     - Ελληνικά
+  -
+    - en
+    - English
   -
     - es
     - Español/Castellano
@@ -94,6 +91,9 @@ languages:
     - he
     - עברית
   -
+    - id
+    - Bahasa
+  -
     - is
     - Íslenska
   -
@@ -103,11 +103,14 @@ languages:
     - ja
     - 日本語
   -
-    - lv
-    - Latviešu
+    - ko
+    - 한국어
   -
     - lt
     - Lietuvių
+  -
+    - lv
+    - Latviešu
   -
     - nl
     - Nederlands (Belgisch)
@@ -126,9 +129,6 @@ languages:
   -
     - zh_TW
     - 繁體中文
-  -
-    - ko
-    - 한국어
 
 toc:
   - guide
@@ -168,25 +168,25 @@ meta:
     translate_link: true
     title: Open Data Glossary
     languages:
-      - en
-      - id
       - de
       - el
+      - en
       - es
       - fr
       - he
+      - id
       - is
       - it
       - ja
-      - lv
+      - ko
       - lt
+      - lv
       - nl
       - pt_BR
       - ro
       - ru
       - zh_CN
       - zh_TW
-      - ko
   guide:
     label: guide
     output: true
@@ -194,25 +194,25 @@ meta:
     translate_link: true
     title: Guide
     languages:
-      - en
-      - id
       - de
       - el
+      - en
       - es
       - fr
       - he
+      - id
       - is
       - it
       - ja
-      - lv
+      - ko
       - lt
+      - lv
       - nl
       - pt_BR
       - ro
       - ru
       - zh_CN
       - zh_TW
-      - ko
     toc:
       entry_point: 'introduction'
       order:

--- a/contribute/editing.html
+++ b/contribute/editing.html
@@ -32,9 +32,7 @@ authors:
 
 <h2>2: Make your changes</h2>
 
-With the editable content in front of you, you’re probably either thinking “great, let’s get editing”, or “hang on, this looks a bit weird”. In case it’s the latter, let’s have a closer look.
-
-The first thing to recognise is the ‘Front Matter’, which will look like this:
+<p>With the editable content in front of you, you’re probably either thinking “great, let’s get editing”, or “hang on, this looks a bit weird”. In case it’s the latter, let’s have a closer look. The first thing to recognise is the ‘Front Matter’, which will look like this:</p>
 
 <pre>
 <code>---
@@ -69,7 +67,7 @@ title: Introduction
   <li>journalists</li>
   <li>politicians</li>
 </ul>
-<br>
+
 <p>Links are created like so:</p>
 
 <pre>

--- a/contribute/translate-glossary.html
+++ b/contribute/translate-glossary.html
@@ -6,22 +6,26 @@ authors:
  - Mor Rubinstein
 ---
 
-<h2> What's new in the glossary</h2>
-<p>In the old version of the handbook, the glossary was one page with all of the term in it. In the new version, we gave each glossary a webpage for better referencing and linking.<\p>
-Glossaries that were translated in the old version of the handbook have been transfered to the new site. Please checkCheck if your language has an old version of the glossary -
-. You can find them <a href=https://github.com https://github.com/{{ site.github_username }}/tree/gh-pages/glossary> here </a>
+<h2>What's new in the glossary</h2>
 
-<h3><b>If you do have an old version translated, follow these steps:</b></h3>
-<p> The old glossary format does not allow linking from the new version of the guide, and you will need to transfer the term to the new format.</p>
+<p>In the old version of the handbook, the glossary was one page with all of the term in it. In the new version, we gave each glossary a webpage for better referencing and linking.</p>
 
-<h3> 1. Create a new folder for the term</h3>
+<p>Glossaries that were translated in the old version of the handbook have been transfered to the new site. Please check if your language has an old version of the glossary. You can find them <a href="https://github.com/{{ site.github_username }}/{{ site.github_repo }}/tree/gh-pages/glossary" rel="external">here</a>.
 
-<p>Under your language folder, Follow the breadcrumb trail <code>{{ site.github_repo }} / glossary / es /</code>, to the right of which is a plus symbol <code><strong>+</strong></code>. create a folder for each term by pressing on the '+' sign and type the term name in English. The folder names should be in lower-case letters with dashes ‘-’ instead of white spaces. Add a ‘/’ in the end of the name to create a new folder.</p>
+<h2>If you do have an old version translated, follow these steps:</h2>
 
-<h3> 2. Translate the term</h3>
-<p> open a new index.md file by clicking on the '+'. </p>
+<p>The old glossary format does not allow linking from the new version of the guide, and you will need to transfer the term to the new format.</p>
 
-In the text editor below add the front matter:
+<h3>1. Create a new folder for the term</h3>
+
+<p>Under your language folder, follow the breadcrumb trail <code>{{ site.github_repo }}/glossary/es/</code>, to the right of which is a plus symbol <code class="icon-plus"><span>[plus icon]</span></code>. Create a folder for each term by pressing on the plus symbol <code class="icon-plus"><span>[plus icon]</span></code> and type the term name in English. The folder name should be in lower-case letters with dashes ('-') instead of white spaces. Add a slash ('/') in the end of the name to create a new folder.</p>
+
+<h3>2. Translate the term</h3>
+
+<p>Open a new 'index.md' file by clicking on the plus symbol <code class="icon-plus"><span>[plus icon]</span></code>.</p>
+
+<p>In the text editor below add the front matter:</p>
+
 <pre>
 ---
 section: terms
@@ -30,22 +34,23 @@ title: Bulk
 ---
 </pre>
 
-<p> Change the 'lang' field to your language code. Change the title to the term title in YOUR language.</p>
+<p>Change the 'lang' field to your language code. Change the title to the term title in YOUR language.</p>
 <p>Below the front matter copy the term from the old glossary.</p>
 
-<h3> 3. Make a pull request.</h3>
+<h3>3. Make a pull request.</h3>
 
 <p>All done! Keep doing this until all terms got their own folder and page.</p>
 
-<h2><b>If you have never translated the glossary before, follow the these steps:</b></h2>
+<h2>If you have never translated the glossary before, follow the these steps:</h2>
 
-<h3> Copy the English Glossary</h3>
+<h3>1. Copy the English glossary</h3>
 
-<p> Copy the English terms directory into your target language directory in the glossary folder. This step can not be done through the Github website and you will have to fork the handbook for you machine. Information about forking and cloning can be find <a href=https://help.github.com/articles/fork-a-repo/>here</a> . Notice, some languages have already been moved and translated. Check the folder to make sure you are not overwriting someone’s work.</p>
+<p>Copy the English terms directory into your target language directory in the glossary folder. This step can not be done through the Github website and you will have to fork the handbook for your machine. Information about forking and cloning can be find <a href="https://help.github.com/articles/fork-a-repo/" rel="external">here</a>. Notice, some languages have already been moved and translated. Check the folder to make sure you are not overwriting someone's work.</p>
 
-<h3>Edit the term</h3>
+<h3>2. Edit the term</h3>
 
-<p>Choose a term and open the index.md file.</p>
+<p>Choose a term and open the 'index.md' file.</p>
+
 <p>The front matter looks as follows:</p>
 
 <pre>
@@ -56,10 +61,10 @@ title: Bulk
 ---
 </pre>
 
-<p>Change the lang field to your language code.</p>
-<p>Change the title to the term title in YOUR language.</p>
+<p>Change the lang field to your language code. Change the title to the term title in YOUR language.</p>
+
 <p>In the text editor, below the front matter, enter your translation to the term.</p>
 
 <h3>3. Submit changes through a pull request.</h3>
 
-<p> All done! Thank you for your help! </p>
+<p>All done! Thank you for your help!</p>

--- a/contribute/translate-guide.html
+++ b/contribute/translate-guide.html
@@ -12,16 +12,17 @@ authors:
 
 <h2>1. Create a new language folder</h2>
 
-<p>In github, under the breadcrumb - <code>{{ site.github_repo }} / guide/</code>  there will be a '+' sign. Click on it and enter your <a href="http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes" rel="external">two letter languages code</a>. Add a dash ('/') after the two letter to create a folder.</p>
+<p>In github, under the breadcrumb - <code>{{ site.github_repo }}/guide/</code>  there will be a plus symbol <code class="icon-plus"><span>[plus icon]</span></code>. Click on it and enter your <a href="http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes" rel="external">two letter languages code</a>. Add a slash ('/') after the two letter to create a folder.</p>
 
 <h2>2. Create a page folder</h2>
 
-<p>Now you will see your language code and a '+' sign on the breadcrumb. Add a page name that you want to translate in <strong>English</strong> and add a dash at the end.</p>
+<p>Now you will see your language code and a plus symbol <code class="icon-plus"><span>[plus icon]</span></code> on the breadcrumb. Add a page name that you want to translate in <strong>English</strong> and add a slash at the end.</p>
 
 <h2>3. Translate the content</h2>
 
-<p>You will now see a new '+' sign. Add the file name 'index.md'.
-In the text editor add the following front matter:</p>
+<p>You will now see a new plus symbol <code class="icon-plus"><span>[plus icon]</span></code>. Add the file name 'index.md'.</p>
+
+<p>In the text editor add the following front matter:</p>
 
 <pre>
 ---

--- a/contribute/translate-guide.html
+++ b/contribute/translate-guide.html
@@ -6,36 +6,36 @@ authors:
  - Mor Rubinstein
 ---
 
-Translating the guide is easy, no need to any other software, all you need is a github account!
-Some languages already have translated version of the guide. If you don't have a version in your language, here is how to do it. 
+<p class="lead">Translating the guide is easy, no need to any other software, all you need is a github account!</p>
 
-<h3> 1. Create a new language folder </h3>
+<p>Some languages already have translated versions of the guide. If you don't have a version in your language, here is how to do it.</p>
 
-In github, under the breadcrumb - <code>{{ site.github_repo }} / guide/</code>  there will be a '+' sign. Click on it and enter your <a http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes >your two letter languages code</a>. Add a dash ('/') after the two letter to create a folder. 
+<h2>1. Create a new language folder</h2>
 
-<h3> 2. Create a page folder</h3>
+<p>In github, under the breadcrumb - <code>{{ site.github_repo }} / guide/</code>  there will be a '+' sign. Click on it and enter your <a href="http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes" rel="external">two letter languages code</a>. Add a dash ('/') after the two letter to create a folder.</p>
 
-Now you will see you languages code and a '+' sign on the breadcrumb. Add a the page name that you want to translate in __English__ and add a dash at the end. 
+<h2>2. Create a page folder</h2>
 
-<h3> 3. translate the content</h3>
+<p>Now you will see your language code and a '+' sign on the breadcrumb. Add a page name that you want to translate in <strong>English</strong> and add a dash at the end.</p>
 
-You will now see a new '+' sign. Add the file name 'index.md'.
-In the text editor add the following front matter:
+<h2>3. Translate the content</h2>
+
+<p>You will now see a new '+' sign. Add the file name 'index.md'.
+In the text editor add the following front matter:</p>
+
 <pre>
 ---
 section: guide
-lang: Your language two letter code
+lang: The two letter code for your language
 title: The title in your language
 ---
 </pre>
 
-Translate as usual.
+<p>Translate as usual.</p>
 
-<h3> 4. Create a pull request</h3>
-If all good, we will add it to the site.
+<h2> 4. Create a pull request</h2>
 
-Repeat for other parts of the guide if needed. 
+<p>If all good, we will add it to the site.<p>
 
-That's it, you are all done!
-
-Thank you for helping us to make the guide accessiable to others!
+<p>Repeat for other parts of the guide if needed. That's it, you are all done!<br>
+Thank you for helping us to make the guide accessiable to others!</p>

--- a/glossary/en/terms/cost-recovery/index.md
+++ b/glossary/en/terms/cost-recovery/index.md
@@ -4,4 +4,4 @@ lang: en
 title: Cost recovery
 ---
 
-The principle of setting a price for a resource, e.g. data, aiming to recover the cost of collecting the data, as distinct from [marginal cost](../marginal-cost/). Data charged for on a cost-recovery basis is not open data according to the [Open Definition](../open-definition/). Studies show that charging for PSI on a cost-recovery basis leads to lower growth than free or marginal-cost pricing
+The principle of setting a price for a resource, e.g. data, aiming to recover the cost of collecting the data, as distinct from [marginal cost](../marginal-cost/). Data charged for on a cost-recovery basis is not open data according to the [Open Definition](../open-definition/). Studies show that charging for PSI on a cost-recovery basis leads to lower growth than free or marginal-cost pricing.


### PR DESCRIPTION
Fixed typos on:
- Translating the guide
- Translating the glossary

Tidied up:
- Translating the guide
- Translating the glossary
- Editing a page

Changed the order of the languages to alphabetical to be impartial.
