### PR TITLE
Fix the links to other terms in the glossary

### DIFF
--- a/_layouts/glossary.html
+++ b/_layouts/glossary.html
@@ -9,7 +9,7 @@ edit: true
   {% for term in sorted_pages %}
   {% if term.section == 'terms' and term.lang == page.lang %}
   <dt>{{ term.title }} [<a href="{{ term.url }}">Permalink</a>]</dt>
-  <dd>{{ term.content | markdownify }}</dd>
+  <dd>{{ term.content | markdownify | replace: 'href="../', 'href="terms/' }}</dd>
   {% endif %}
   {% endfor %}
 </dl>

--- a/_layouts/glossary.html
+++ b/_layouts/glossary.html
@@ -9,7 +9,7 @@ edit: true
   {% for term in sorted_pages %}
   {% if term.section == 'terms' and term.lang == page.lang %}
   <dt>{{ term.title }} [<a href="{{ term.url }}">Permalink</a>]</dt>
-  <dd>{{ term.content }}</dd>
+  <dd>{{ term.content | markdownify }}</dd>
   {% endif %}
   {% endfor %}
 </dl>


### PR DESCRIPTION
I applied the `markdownify` filter to the content of each term in the glossary index page, then the `replace` filter to it to fix the links to other terms. This is a kind of quick fix. Regarding the comment of @rgrp in https://github.com/okfn/opendatahandbook/pull/172#issuecomment-127415862, it is easy to remove links, but I'm not sure that's the better way than this.
