### PR TITLE
Fix outdated or broken links in the glossary

### DIFF
--- a/glossary/en/terms/discoverable/index.md
+++ b/glossary/en/terms/discoverable/index.md
@@ -4,5 +4,4 @@ lang: en
 title: Discoverable
 ---
 
-It is not enough for open data to be published if potential users cannot find it, or even do not know that it exists. Rather than simply publishing data haphazardly on websites, governments and other large data publishers can help make their datasets discoverable by indexing them in catalogues or {data portals}.
-
+It is not enough for open data to be published if potential users cannot find it, or even do not know that it exists. Rather than simply publishing data haphazardly on websites, governments and other large data publishers can help make their datasets discoverable by indexing them in catalogues or [data portals](../data-portal/).

--- a/glossary/it/terms/discoverable/index.md
+++ b/glossary/it/terms/discoverable/index.md
@@ -4,4 +4,4 @@ lang: it
 title: Rintracciabili / Discoverable
 ---
 
-Non è sufficiente che gli open data siano pubblicati se i potenziali utenti non riescono a trovarli, o addirittura non sanno che esistono. Piuttosto che limitarsi a pubblicare i dati a casaccio su siti web, i governi ed altri pubblicatori di dati di grandi dimensioni possono contribuire a rendere i propri dataset rintracciabili con l'indicizzazione dei loro cataloghi o nei [portali di dati](../data-portals/).
+Non è sufficiente che gli open data siano pubblicati se i potenziali utenti non riescono a trovarli, o addirittura non sanno che esistono. Piuttosto che limitarsi a pubblicare i dati a casaccio su siti web, i governi ed altri pubblicatori di dati di grandi dimensioni possono contribuire a rendere i propri dataset rintracciabili con l'indicizzazione dei loro cataloghi o nei [portali di dati](../data-portal/).


### PR DESCRIPTION
Fixed an outdated link in the term 'discoverable' of the English glossary and a broken link in the term 'discoverable' of the Italian glossary.
