### PR TITLE
Update related projects

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -311,8 +311,8 @@ related_projects:
       name: The DataHub
       link: http://datahub.io/
   -
-      name: DataCatalogs.org
-      link: http://datacatalogs.org/
+      name: DataPortals.org
+      link: http://dataportals.org/
   -
       name: OpenSpending.org
       link: http://openspending.org/


### PR DESCRIPTION
Changed DataCatalogs.org to DataPortals.org, closing https://github.com/okfn/opendatahandbook/issues/192.
