### PR TITLE
Add a missing period

### DIFF
--- a/glossary/en/terms/open-source/index.md
+++ b/glossary/en/terms/open-source/index.md
@@ -4,4 +4,4 @@ lang: en
 title: Open Source
 ---
 
-Software for which the [source code](../source-code/) is available under an open licence. Not only can the software be used for free, but users with the necessary technical skills can inspect the source code, modify it and run their own versions of the code, helping to fix bugs, develop new features, etc. Some large open source software projects have thousands of volunteer contributors. The [Open Definition](../open-definition/) was heavily based on the earlier Open Source Definition, which sets out the conditions under which software can be considered open source
+Software for which the [source code](../source-code/) is available under an open licence. Not only can the software be used for free, but users with the necessary technical skills can inspect the source code, modify it and run their own versions of the code, helping to fix bugs, develop new features, etc. Some large open source software projects have thousands of volunteer contributors. The [Open Definition](../open-definition/) was heavily based on the earlier Open Source Definition, which sets out the conditions under which software can be considered open source.


### PR DESCRIPTION
Added a missing period to the term 'open source' in the English glossary.
