### PR TITLE
Fix a small typo in the glossary

### DIFF
--- a/glossary/en/terms/shapefile/index.md
+++ b/glossary/en/terms/shapefile/index.md
@@ -4,4 +4,4 @@ lang: en
 title: Shapefile
 ---
 
-A popular [file format](../file-format/) for [geodata](../geodata/), maintained and published by Esri, a manufacturer of [GIS](../gis/) software. A Shapefile actually consists of several related files. Though the format is technically [proprietary](../proprietary/), Esri publish a full specification [standard](../standard/) and Shapefiles can be read by a wide range of software, so function somewhat like an open standard in practice.
+A popular [file format](../file-format/) for [geodata](../geodata/), maintained and published by Esri, a manufacturer of [GIS](../gis/) software. A Shapefile actually consists of several related files. Though the format is technically [proprietary](../proprietary/), Esri publishes a full specification [standard](../standard/) and Shapefiles can be read by a wide range of software, so function somewhat like an open standard in practice.


### PR DESCRIPTION
Fixed a small typo in the term 'shapefile' of the glossary.
