### PR TITLE
Added Open Procure as a resource

### DIFF
--- a/resources/055/index.md
+++ b/resources/055/index.md
@@ -1,0 +1,16 @@
+---
+section: resources
+lang: EN
+Author: multiple
+Country: 'global'
+Description: Open Procure lists public agencies and their respective procurement thresholds. This guide identifies the dollar amount under which a government agency can purchase a product or a service without having to solicit competitive bids.
+Keywords: Procurement, Open Data, Open Goverment, Open Source
+Link: http://openprocure.us/
+MediaType: Website
+Notes: ''
+Publishing_date: 2015
+Publishing_entity: MuniRent
+Region: North America
+Title: Open Procure
+Topic: Right for Information
+---


### PR DESCRIPTION
Open Procure is an open data project that helps make government procurement limits more transparent.
