### PR TITLE
Adding an open data resource

### DIFF
--- a/resources/059/index.md
+++ b/resources/059/index.md
@@ -1,0 +1,16 @@
+--- 
+section: resources 
+lang: EN 
+Author: Makx Dekkers, Nikolaos Loutas, Brecht Wyns 
+Country: Austria, Belgium, Bulgaria, Croatia, Cyprus, Czech Republic, Denmar, Estonia, Finland, France, Germany, Greece, Hungary, Ireland, Italy, Latvia, Lithuania, Luxembourg, Malta, Netherlands, Poland, Portugal, Romania, Slovakia, Slovenia, Spain, Sweden, United Kingdom
+Description: The DCAT Application profile for data portals in Europe (DCAT-AP) is a specification based on the Data Catalogue vocabulary (DCAT) for describing public sector datasets in Europe. Its basic use case is to enable cross-data portal search for data sets and make public sector data better searchable across borders and sectors. This can be achieved by the exchange of descriptions of datasets among data portals. 
+Keywords: DCAT, DCAT-AP, Application Profile, data catalogue, vocabulary, EU, Open Data Portals, Interoperability
+Link: https://joinup.ec.europa.eu/node/63567/ 
+MediaType: Publication 
+Notes: Version 1.0 was published in 2013, version 1.1 was published in 2015
+Publishing_date: 2013
+Publishing_entity: ISA² Programme, European Commission 
+Region: Europe 
+Title: DCAT Application Profile for Data Portals in Europe 
+Topic: Standards 
+---


### PR DESCRIPTION
We would like to add the DCAT-AP as a standard to your resource catalogue. The DCAT-AP is adopted by many open data portals in the EU and allows cross-data portal harvesting & search.